### PR TITLE
Difficulty Modes added easy, medium and hard

### DIFF
--- a/yhma23.ios.groupproject/DifficultyModes.swift
+++ b/yhma23.ios.groupproject/DifficultyModes.swift
@@ -1,0 +1,69 @@
+//
+//  DifficultyModes.swift
+//  yhma23.ios.groupproject
+//
+//  Created by A.S on 2024-04-01.
+//
+
+import UIKit
+
+
+
+class DifficultyModesViewController: UIViewController {
+    
+    let words: [String] = ["easy1", "easy2", "easy3", "easy4", "easy5", "medium1", "medium2", "medium3", "medium4", "medium5", "hard1", "hard2", "hard3", "hard4", "hard5"]
+    var selectedWords: [String] = []
+
+    @IBAction func easyMode(_ sender: UIButton) {
+        startGame(withWords: Array(words[0...4]))
+    }
+    
+    @IBAction func mediumMode(_ sender: Any) {
+        startGame(withWords: Array(words[5...9]))
+    }
+    
+    @IBAction func hardMode(_ sender: Any) {
+        startGame(withWords: Array(words[10...14]))
+    }
+    
+    func startGame(withWords words: [String]) {
+        // Store the selected words in a property
+        selectedWords = words
+
+        // Perform the segue
+        performSegue(withIdentifier: "startGame", sender: self)
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "startGame" {
+            if let gameViewController = segue.destination as? GameViewController {
+                gameViewController.words = selectedWords
+            }
+        }
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}
+
+
+    
+
+    
+    
+
+
+
+
+/*
+ // MARK: - Navigation
+ 
+ // In a storyboard-based application, you will often want to do a little preparation before navigation
+ override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+ // Get the new view controller using segue.destination.
+ // Pass the selected object to the new view controller.
+ }
+ */
+
+


### PR DESCRIPTION
This branch adds DifficultyModes view to the game, letting you choose your challenge between: easy, medium, or hard.

One big word list is used for fairness, with a special twist – the number of words is a multiple of 3 (% 3 = 00),
 This allows for an even split across difficulties, so each level feels balanced.

Each difficulty has a button in DifficultyModes. Clicking a button will get the perfect word set for that level from the list using index numbers and following easy-medium-hard order.

This approach offers two benefits: a balanced experience and future flexibility. You can even use separate word lists later, creating unique challenges for each difficulty!