### PR TITLE
Difficulty Modes added easy, medium and hard

### DIFF
--- a/yhma23.ios.groupproject.xcodeproj/project.pbxproj
+++ b/yhma23.ios.groupproject.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E0285F252BBB3F4D0082E851 /* DifficultyModes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0285F242BBB3F4D0082E851 /* DifficultyModes.swift */; };
 		E1DCB85D2BB7303D00908BDA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DCB85C2BB7303D00908BDA /* AppDelegate.swift */; };
 		E1DCB85F2BB7303D00908BDA /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DCB85E2BB7303D00908BDA /* SceneDelegate.swift */; };
 		E1DCB8642BB7303D00908BDA /* Base in Resources */ = {isa = PBXBuildFile; fileRef = E1DCB8632BB7303D00908BDA /* Base */; };
@@ -21,6 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		E0285F242BBB3F4D0082E851 /* DifficultyModes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DifficultyModes.swift; sourceTree = "<group>"; };
 		E1DCB8592BB7303D00908BDA /* yhma23.ios.groupproject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = yhma23.ios.groupproject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1DCB85C2BB7303D00908BDA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E1DCB85E2BB7303D00908BDA /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 				E1DCB8782BB73BC300908BDA /* Highscore.swift */,
 				E1DCB87A2BB73BF600908BDA /* GameModel.swift */,
 				E1DCB87C2BB73D0900908BDA /* StartViewController.swift */,
+				E0285F242BBB3F4D0082E851 /* DifficultyModes.swift */,
 			);
 			path = yhma23.ios.groupproject;
 			sourceTree = "<group>";
@@ -161,6 +164,7 @@
 				E1DCB87B2BB73BF600908BDA /* GameModel.swift in Sources */,
 				E1DCB8792BB73BC300908BDA /* Highscore.swift in Sources */,
 				E1DCB8772BB73A8E00908BDA /* HighscoreTableViewController.swift in Sources */,
+				E0285F252BBB3F4D0082E851 /* DifficultyModes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/yhma23.ios.groupproject/Base.lproj/Main.storyboard
+++ b/yhma23.ios.groupproject/Base.lproj/Main.storyboard
@@ -25,7 +25,7 @@
                                 </buttonConfiguration>
                                 <connections>
                                     <action selector="startGameButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1Ov-lC-vFg"/>
-                                    <segue destination="6GA-c4-81N" kind="show" id="v6E-Ih-UcO"/>
+                                    <segue destination="uMh-xz-ZLa" kind="show" id="FyI-qH-qCZ"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kR7-ZE-Wll">
@@ -122,7 +122,87 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TAt-xt-Oi2" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="20.610687022900763" y="655.63380281690149"/>
+            <point key="canvasLocation" x="21" y="679"/>
+        </scene>
+        <!--Game Modes View-->
+        <scene sceneID="YHI-PZ-oZd">
+            <objects>
+                <viewController title="Game Modes View" id="uMh-xz-ZLa" customClass="DifficultyModes" customModule="yhma23_ios_groupproject" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ik4-Wd-tDg">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pw9-rn-nFk">
+                                <rect key="frame" x="153.66666666666666" y="467" width="85.666666666666657" height="38.333333333333314"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Medium">
+                                    <color key="baseForegroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="baseBackgroundColor" red="1" green="0.91265018019999999" blue="0.87650665849999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="MediumMode:" destination="hZv-yu-HgU" eventType="touchUpInside" id="LZ7-pD-oyM"/>
+                                    <action selector="mediumMode:" destination="uMh-xz-ZLa" eventType="touchUpInside" id="O6O-JW-dCg"/>
+                                    <action selector="playButton:" destination="9UD-O5-BhT" eventType="touchUpInside" id="QiF-jn-K9r"/>
+                                    <segue destination="6GA-c4-81N" kind="showDetail" identifier="startGame" id="MvS-Hg-PvK"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jve-H1-8SH">
+                                <rect key="frame" x="166" y="567" width="61" height="38.333333333333371"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Hard">
+                                    <color key="baseForegroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="baseBackgroundColor" red="1" green="0.91265018019999999" blue="0.87650665849999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="HardMode:" destination="hZv-yu-HgU" eventType="touchUpInside" id="rGM-Ma-GnC"/>
+                                    <action selector="hardMode:" destination="uMh-xz-ZLa" eventType="touchUpInside" id="xYw-A7-yAb"/>
+                                    <action selector="playButton:" destination="9UD-O5-BhT" eventType="touchUpInside" id="Y28-ZO-N9I"/>
+                                    <segue destination="6GA-c4-81N" kind="showDetail" identifier="startGame" id="MzH-4e-B3a"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select Game Mode" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qrj-Mg-sHr">
+                                <rect key="frame" x="41.666666666666657" y="260" width="310" height="45.666666666666686"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="38"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" tag="1" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v8e-ex-veX">
+                                <rect key="frame" x="170" y="358" width="59.666666666666657" height="38.333333333333314"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Easy">
+                                    <color key="baseForegroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="baseBackgroundColor" red="1" green="0.91265018019999999" blue="0.87650665849999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="EasyMode:" destination="hZv-yu-HgU" eventType="touchUpInside" id="XNk-9V-fTA"/>
+                                    <action selector="easyMode:" destination="uMh-xz-ZLa" eventType="touchUpInside" id="vCb-Hb-TZM"/>
+                                    <action selector="playButton:" destination="9UD-O5-BhT" eventType="touchUpInside" id="C2z-Ad-rbM"/>
+                                    <segue destination="6GA-c4-81N" kind="showDetail" identifier="startGame" id="aXG-ZT-otm"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="67p-97-kqr"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="jve-H1-8SH" firstAttribute="centerX" secondItem="Ik4-Wd-tDg" secondAttribute="centerX" id="60Q-Xh-kRd"/>
+                            <constraint firstItem="v8e-ex-veX" firstAttribute="centerX" secondItem="Ik4-Wd-tDg" secondAttribute="centerX" id="96f-dl-kTT"/>
+                            <constraint firstItem="qrj-Mg-sHr" firstAttribute="top" secondItem="67p-97-kqr" secondAttribute="top" constant="260" id="SAC-tM-X9b"/>
+                            <constraint firstItem="qrj-Mg-sHr" firstAttribute="centerX" secondItem="Ik4-Wd-tDg" secondAttribute="centerX" id="VDZ-HR-SKg"/>
+                            <constraint firstItem="pw9-rn-nFk" firstAttribute="centerX" secondItem="Ik4-Wd-tDg" secondAttribute="centerX" id="ZGV-97-wcs"/>
+                            <constraint firstItem="pw9-rn-nFk" firstAttribute="top" secondItem="v8e-ex-veX" secondAttribute="bottom" constant="66" id="d1n-ln-HRl"/>
+                            <constraint firstItem="v8e-ex-veX" firstAttribute="top" secondItem="qrj-Mg-sHr" secondAttribute="bottom" constant="57" id="l1F-P3-mC9"/>
+                            <constraint firstItem="jve-H1-8SH" firstAttribute="top" secondItem="pw9-rn-nFk" secondAttribute="bottom" constant="61.670000000000002" id="vQv-DG-TPc"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="XkK-m8-GxC"/>
+                    <connections>
+                        <segue destination="6GA-c4-81N" kind="showDetail" identifier="startGame" id="Qt8-Ec-e2f"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ggC-X6-HgK" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="hZv-yu-HgU" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="750" y="4"/>
         </scene>
         <!--Game View Controller-->
         <scene sceneID="zWp-9a-uem">
@@ -195,7 +275,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bSd-Vp-4Bc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="719.84732824427476" y="3.5211267605633805"/>
+            <point key="canvasLocation" x="711" y="679"/>
         </scene>
         <!--End View Controller-->
         <scene sceneID="HJU-rX-XkE">
@@ -214,7 +294,7 @@
                                 </buttonConfiguration>
                                 <connections>
                                     <action selector="playAgainButton:" destination="Se5-8v-jxO" eventType="touchUpInside" id="kPM-z8-ree"/>
-                                    <segue destination="6GA-c4-81N" kind="show" id="yUr-It-JjT"/>
+                                    <segue destination="6GA-c4-81N" kind="show" identifier="" id="yUr-It-JjT"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YCi-CN-Agr">
@@ -257,12 +337,12 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Fsl-jv-i7f" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1481.679389312977" y="3.5211267605633805"/>
+            <point key="canvasLocation" x="1410" y="4"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="yUr-It-JjT"/>
-        <segue reference="2fz-hY-iPm"/>
+        <segue reference="Qt8-Ec-e2f"/>
+        <segue reference="N9D-bf-DKL"/>
     </inferredMetricsTieBreakers>
     <resources>
         <systemColor name="systemBackgroundColor">

--- a/yhma23.ios.groupproject/DifficultyModes.swift
+++ b/yhma23.ios.groupproject/DifficultyModes.swift
@@ -9,7 +9,7 @@ import UIKit
 
 
 
-class DifficultyModesViewController: UIViewController {
+class DifficultyModes: UIViewController {
     
     let words: [String] = ["easy1", "easy2", "easy3", "easy4", "easy5", "medium1", "medium2", "medium3", "medium4", "medium5", "hard1", "hard2", "hard3", "hard4", "hard5"]
     var selectedWords: [String] = []

--- a/yhma23.ios.groupproject/GameViewController.swift
+++ b/yhma23.ios.groupproject/GameViewController.swift
@@ -14,8 +14,10 @@ class GameViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var writeTheWordLabel: UILabel!
     @IBOutlet weak var inputWordTextField: UITextField!
     
-    var words: [String] = ["h", "w", "a", "i", "game","Android"]
     var currentWordIndex = 0
+        var words: [String] = []
+
+    
     
     @IBAction func okButton(_ sender: Any) {
         
@@ -25,7 +27,8 @@ class GameViewController: UIViewController, UITextFieldDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+
         // Do any additional setup after loading the view.
         
         let countdownLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
@@ -58,6 +61,7 @@ class GameViewController: UIViewController, UITextFieldDelegate {
             label.isHidden = true
             
             startFallingAnimation()
+
         }
     }
     


### PR DESCRIPTION
This branch adds DifficultyModes view to the game, letting you choose your challenge between: easy, medium, or hard.

One big word list is used for fairness, with a special twist – the number of words is a multiple of 3 (% 3 = 00),
This allows for an even split across difficulties, so each level feels balanced.

Each difficulty has a button in DifficultyModes. Clicking a button will get the perfect word set for that level from the list using index numbers and following easy-medium-hard order.

This approach offers two benefits: a balanced experience and future flexibility. You can even use separate word lists later, creating unique challenges for each difficulty!